### PR TITLE
Create visualize method

### DIFF
--- a/src/dativity/visualize.clj
+++ b/src/dativity/visualize.clj
@@ -4,10 +4,11 @@
     [ysera.error :refer [error]]
     [ysera.test :refer [is=]]))
 
-(defn add-visuals-to-node
+(defn- default-transform-node
   {:test (fn []
-           (is= (add-visuals-to-node {:type :data}) {:type  :data
-                                                     :color :green}))}
+           (is= (default-transform-node {:type :data})
+                {:type  :data
+                 :color :green}))}
   [node]
   (assoc node :color (condp = (:type node)
                        :action :blue
@@ -15,11 +16,12 @@
                        :role :orange
                        (error (format "could not add visuals to %s" node)))))
 
-(defn add-visuals-to-edge
+(defn- default-transform-edge
   {:test (fn []
-           (is= (add-visuals-to-edge {:association :produces}) {:association :produces
-                                                                :color       :green
-                                                                :label       "produces"}))}
+           (is= (default-transform-edge {:association :produces})
+                {:association :produces
+                 :color       :green
+                 :label       "produces"}))}
   [edge]
   (merge edge (condp = (:association edge)
                 :produces {:color :green
@@ -33,12 +35,12 @@
                 (error (format "could not add visuals to %s" edge)))))
 
 (defn- to-uber
-  [graph]
+  [graph transform-node transform-edge]
   (let [nodes (->> (:nodes graph)
-                   (map (fn [[k v]] [k (add-visuals-to-node v)]))
+                   (map (fn [[k v]] [k (transform-node v)]))
                    (vec))
         edges (->> (:edges graph)
-                   (map (fn [[[src dest] v]] [src dest (add-visuals-to-edge v)]))
+                   (map (fn [[[src dest] v]] [src dest (transform-edge v)]))
                    (vec))]
     (uber/edn->ubergraph {:nodes            nodes
                           :directed-edges   edges
@@ -46,8 +48,14 @@
                           :undirected?      false
                           :undirected-edges []})))
 
-;layouts that make sense are :fdp and :dot
+(defn visualize
+  ([graph options]
+   (visualize graph options default-transform-node default-transform-edge))
+  ([graph options transform-node transform-edge]
+   (uber/viz-graph (to-uber graph transform-node transform-edge) options)))
+
+;;layouts that make sense are :fdp and :dot
 (defn generate-png
   "requires graphviz"
   [graph]
-  (uber/viz-graph (to-uber graph) {:layout :dot}))
+  (visualize graph {:layout :dot}))


### PR DESCRIPTION
The existing `generate-png` method is fairly limiting. I've added a new method, `visualize`, which allows you to arbitrarily transform nodes and edges. It also accepts an `options` map that will be passed along to `uber/viz-graph`, which allows for image saving, etc.